### PR TITLE
Fix for Pythia >=8.310

### DIFF
--- a/EvtGenExternal/EvtPythiaEngine.hh
+++ b/EvtGenExternal/EvtPythiaEngine.hh
@@ -82,8 +82,12 @@ class EvtPythiaEngine : public EvtAbsExternalGen {
 
     bool _convertPhysCodes, _initialised, _useEvtGenRandom;
 
-    std::unique_ptr<EvtPythiaRandom> _evtgenRandom;
-
+    #if PYTHIA_VERSION_INTEGER < 8310
+        std::unique_ptr<EvtPythiaRandom> _evtgenRandom;
+    #else
+        std::shared_ptr<EvtPythiaRandom> _evtgenRandom;
+    #endif
+    
     std::map<int, int> _addedPDGCodes;
 };
 

--- a/src/EvtGenExternal/EvtPythiaEngine.cpp
+++ b/src/EvtGenExternal/EvtPythiaEngine.cpp
@@ -75,7 +75,11 @@ EvtPythiaEngine::EvtPythiaEngine( std::string xmlDir, bool convertPhysCodes,
     // from EvtGen for Pythia 8.
     _useEvtGenRandom = useEvtGenRandom;
 
-    _evtgenRandom = std::make_unique<EvtPythiaRandom>();
+    #if PYTHIA_VERSION_INTEGER < 8310
+        _evtgenRandom = std::make_unique<EvtPythiaRandom>();
+    #else
+        _evtgenRandom = std::make_shared<EvtPythiaRandom>();
+    #endif
 
     _initialised = false;
 }
@@ -128,8 +132,13 @@ void EvtPythiaEngine::initialise()
 
     // Set the random number generator
     if ( _useEvtGenRandom == true ) {
-        _genericPythiaGen->setRndmEnginePtr( _evtgenRandom.get() );
-        _aliasPythiaGen->setRndmEnginePtr( _evtgenRandom.get() );
+        #if PYTHIA_VERSION_INTEGER < 8310
+            _genericPythiaGen->setRndmEnginePtr( _evtgenRandom.get() );
+            _aliasPythiaGen->setRndmEnginePtr( _evtgenRandom.get() );
+        #else
+            _genericPythiaGen->setRndmEnginePtr( _evtgenRandom );
+            _aliasPythiaGen->setRndmEnginePtr( _evtgenRandom );
+        #endif
     }
 
     _genericPythiaGen->init();


### PR DESCRIPTION
The interface of setRndmEnginePtr has changed in Pythia versions starting from 8.310. A possible solution has been implemented which selects the pointer type at compilation time.